### PR TITLE
Accept symfony/process & symfony/finder ^6.0 in the composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php": "^8.0",
-        "symfony/process": "^3.4|^4.1|^5.0"
+        "symfony/process": "^3.4|^4.1|^5.0|^6.0"
     },
     "require-dev": {
         "phing/phing": "^2.14",
         "phpunit/phpunit": "^9.5",
         "scrutinizer/ocular": "^1.3",
-        "symfony/finder": "^4.1",
+        "symfony/finder": "^4.1|^5.0|^6.0",
         "sebastian/comparator": ">=1.2.3"
     },
     "autoload": {


### PR DESCRIPTION
I checked the library on my project with SF6, and it went fine.