### PR TITLE
Add interface for Ghostcript and move version check to device process

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $ curl -s https://getcomposer.org/installer | php
 Require the package via Composer:
 
 ```bash
-$ php composer.phar require gravitymedia/ghostscript:v2.2
+$ php composer.phar require gravitymedia/ghostscript:v2.3
 ```
 
 ## Usage

--- a/src/Device/AbstractDevice.php
+++ b/src/Device/AbstractDevice.php
@@ -74,7 +74,7 @@ abstract class AbstractDevice
     /**
      * The Ghostscript object.
      */
-    private GhostscriptInterface $ghostscript;
+    protected GhostscriptInterface $ghostscript;
 
     /**
      * The arguments object.

--- a/src/Device/AbstractDevice.php
+++ b/src/Device/AbstractDevice.php
@@ -229,7 +229,7 @@ abstract class AbstractDevice
 
         $input = $this->sanitizeInput($input);
 
-        $arguments = $this->createProcessArguments($input, $version);
+        $arguments = $this->createProcessArguments($input);
         array_unshift(
             $arguments,
             $this->ghostscript->getOption('bin', Ghostscript::DEFAULT_BINARY)

--- a/src/Device/AbstractDevice.php
+++ b/src/Device/AbstractDevice.php
@@ -184,7 +184,7 @@ abstract class AbstractDevice
      *
      * @return array
      */
-    protected function createProcessArguments(Input $input, string $version)
+    protected function createProcessArguments(Input $input)
     {
         $arguments = array_values($this->arguments->toArray());
 

--- a/src/Device/BoundingBoxInfo.php
+++ b/src/Device/BoundingBoxInfo.php
@@ -8,6 +8,7 @@
 namespace GravityMedia\Ghostscript\Device;
 
 use GravityMedia\Ghostscript\Ghostscript;
+use GravityMedia\Ghostscript\GhostscriptInterface;
 use GravityMedia\Ghostscript\Process\Arguments;
 
 /**
@@ -25,7 +26,7 @@ class BoundingBoxInfo extends AbstractDevice
      * @param Ghostscript $ghostscript
      * @param Arguments   $arguments
      */
-    public function __construct(Ghostscript $ghostscript, Arguments $arguments)
+    public function __construct(GhostscriptInterface $ghostscript, Arguments $arguments)
     {
         parent::__construct($ghostscript, $arguments->setArgument('-sDEVICE=bbox'));
     }

--- a/src/Device/Inkcov.php
+++ b/src/Device/Inkcov.php
@@ -6,6 +6,7 @@
 namespace GravityMedia\Ghostscript\Device;
 
 use GravityMedia\Ghostscript\Ghostscript;
+use GravityMedia\Ghostscript\GhostscriptInterface;
 use GravityMedia\Ghostscript\Process\Arguments as ProcessArguments;
 use GravityMedia\Ghostscript\Process\Arguments;
 
@@ -14,13 +15,11 @@ use GravityMedia\Ghostscript\Process\Arguments;
  */
 class Inkcov extends AbstractDevice
 {
-    const POSTSCRIPT_COMMANDS = '';
-
     /**
      * @param Ghostscript $ghostscript
      * @param ProcessArguments $arguments
      */
-    public function __construct(Ghostscript $ghostscript, Arguments $arguments)
+    public function __construct(GhostscriptInterface $ghostscript, Arguments $arguments)
     {
         parent::__construct($ghostscript, $arguments->setArgument('-sDEVICE=inkcov'));
     }

--- a/src/Device/NoDisplay.php
+++ b/src/Device/NoDisplay.php
@@ -8,6 +8,7 @@
 namespace GravityMedia\Ghostscript\Device;
 
 use GravityMedia\Ghostscript\Ghostscript;
+use GravityMedia\Ghostscript\GhostscriptInterface;
 use GravityMedia\Ghostscript\Process\Arguments;
 
 /**
@@ -23,7 +24,7 @@ class NoDisplay extends AbstractDevice
      * @param Ghostscript $ghostscript
      * @param Arguments   $arguments
      */
-    public function __construct(Ghostscript $ghostscript, Arguments $arguments)
+    public function __construct(GhostscriptInterface $ghostscript, Arguments $arguments)
     {
         parent::__construct($ghostscript, $arguments->setArgument('-dNODISPLAY'));
     }

--- a/src/Device/PdfInfo.php
+++ b/src/Device/PdfInfo.php
@@ -8,6 +8,7 @@
 namespace GravityMedia\Ghostscript\Device;
 
 use GravityMedia\Ghostscript\Ghostscript;
+use GravityMedia\Ghostscript\GhostscriptInterface;
 use GravityMedia\Ghostscript\Process\Arguments;
 
 /**
@@ -23,10 +24,8 @@ class PdfInfo extends NoDisplay
 {
     /**
      * The PDF info path.
-     *
-     * @var string
      */
-    private $pdfInfoPath;
+    private string $pdfInfoPath;
 
     /**
      * Create PDF info device object.
@@ -35,7 +34,7 @@ class PdfInfo extends NoDisplay
      * @param Arguments   $arguments
      * @param string      $pdfInfoPath Path to toolbin/pdf_info.ps
      */
-    public function __construct(Ghostscript $ghostscript, Arguments $arguments, $pdfInfoPath)
+    public function __construct(GhostscriptInterface $ghostscript, Arguments $arguments, $pdfInfoPath)
     {
         parent::__construct($ghostscript, $arguments);
 

--- a/src/Device/PdfWrite.php
+++ b/src/Device/PdfWrite.php
@@ -163,7 +163,7 @@ class PdfWrite extends AbstractDevice
     /**
      * {@inheritdoc}
      */
-    protected function createProcessArguments(Input $input, string $version)
+    protected function createProcessArguments(Input $input)
     {
         $code = $input->getPostScriptCode();
         if (null === $code) {

--- a/src/Device/PdfWrite.php
+++ b/src/Device/PdfWrite.php
@@ -181,6 +181,6 @@ class PdfWrite extends AbstractDevice
             $input->setPostScriptCode(ltrim($code . ' .setpdfwrite', ' '));
         }
 
-        return parent::createProcessArguments($input, $version);
+        return parent::createProcessArguments($input);
     }
 }

--- a/src/Device/PdfWrite.php
+++ b/src/Device/PdfWrite.php
@@ -177,7 +177,7 @@ class PdfWrite extends AbstractDevice
          * the pdfwrite device.
          * @link https://ghostscript.com/doc/current/Language.htm#.setpdfwrite
          */
-        if (version_compare($version, '9.50', '<') && false === strstr($code, '.setpdfwrite')) {
+        if (version_compare($this->ghostscript->getVersion(), '9.50', '<') && false === strstr($code, '.setpdfwrite')) {
             $input->setPostScriptCode(ltrim($code . ' .setpdfwrite', ' '));
         }
 

--- a/src/Device/PdfWrite.php
+++ b/src/Device/PdfWrite.php
@@ -10,6 +10,7 @@ namespace GravityMedia\Ghostscript\Device;
 use GravityMedia\Ghostscript\Enum\PdfSettings;
 use GravityMedia\Ghostscript\Enum\ProcessColorModel;
 use GravityMedia\Ghostscript\Ghostscript;
+use GravityMedia\Ghostscript\GhostscriptInterface;
 use GravityMedia\Ghostscript\Input;
 use GravityMedia\Ghostscript\Process\Arguments;
 
@@ -61,23 +62,15 @@ class PdfWrite extends AbstractDevice
     use DistillerParameters\AdvancedTrait;
 
     /**
-     * The Ghostscript binary version.
-     *
-     * @var string
-     */
-    protected $ghostscriptVersion;
-
-    /**
      * Create PDF write device object.
      *
      * @param Ghostscript $ghostscript
      * @param Arguments   $arguments
      */
-    public function __construct(Ghostscript $ghostscript, Arguments $arguments)
+    public function __construct(GhostscriptInterface $ghostscript, Arguments $arguments)
     {
         parent::__construct($ghostscript, $arguments->setArgument('-sDEVICE=pdfwrite'));
 
-        $this->ghostscriptVersion = $ghostscript->getVersion();
         $this->setPdfSettings(PdfSettings::__DEFAULT);
     }
 
@@ -170,7 +163,7 @@ class PdfWrite extends AbstractDevice
     /**
      * {@inheritdoc}
      */
-    protected function createProcessArguments(Input $input)
+    protected function createProcessArguments(Input $input, string $version)
     {
         $code = $input->getPostScriptCode();
         if (null === $code) {
@@ -184,10 +177,10 @@ class PdfWrite extends AbstractDevice
          * the pdfwrite device.
          * @link https://ghostscript.com/doc/current/Language.htm#.setpdfwrite
          */
-        if (version_compare($this->ghostscriptVersion, '9.50', '<') && false === strstr($code, '.setpdfwrite')) {
+        if (version_compare($version, '9.50', '<') && false === strstr($code, '.setpdfwrite')) {
             $input->setPostScriptCode(ltrim($code . ' .setpdfwrite', ' '));
         }
 
-        return parent::createProcessArguments($input);
+        return parent::createProcessArguments($input, $version);
     }
 }

--- a/src/Ghostscript.php
+++ b/src/Ghostscript.php
@@ -20,7 +20,7 @@ use Symfony\Component\Process\Process;
  *
  * @package GravityMedia\Ghostscript
  */
-class Ghostscript
+class Ghostscript implements GhostscriptInterface
 {
     /**
      * The default binary.
@@ -39,7 +39,8 @@ class Ghostscript
      *
      * @var array
      */
-    protected $options;
+    protected $options = [];
+
 
     /**
      * Create Ghostscript object.
@@ -51,10 +52,6 @@ class Ghostscript
     public function __construct(array $options = [])
     {
         $this->options = $options;
-
-        if (version_compare('9.00', $this->getVersion()) > 0) {
-            throw new \RuntimeException('Ghostscript version 9.00 or higher is required');
-        }
     }
 
     /**

--- a/src/GhostscriptInterface.php
+++ b/src/GhostscriptInterface.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * This file is part of the Ghostscript package.
+ *
+ * @author Daniel Schröder <daniel.schroeder@gravitymedia.de>
+ */
+
+namespace GravityMedia\Ghostscript;
+
+use GravityMedia\Ghostscript\Device\BoundingBoxInfo;
+use GravityMedia\Ghostscript\Device\Inkcov;
+use GravityMedia\Ghostscript\Device\NoDisplay;
+use GravityMedia\Ghostscript\Device\PdfInfo;
+use GravityMedia\Ghostscript\Device\PdfWrite;
+
+/**
+ * @package GravityMedia\Ghostscript
+ */
+interface GhostscriptInterface
+{
+    /**
+     * Get option.
+     *
+     * @param string $name
+     * @param mixed  $default
+     *
+     * @return mixed
+     */
+    public function getOption($name, $default = null);
+
+    /**
+     * Get version.
+     *
+     * @return string
+     * @throws \RuntimeException
+     *
+     */
+    public function getVersion();
+
+    /**
+     * Create PDF device object.
+     *
+     * @param null|string $outputFile
+     *
+     * @return PdfWrite
+     */
+    public function createPdfDevice($outputFile = null);
+
+    /**
+     * Create no display device object.
+     *
+     * @return NoDisplay
+     */
+    public function createNoDisplayDevice();
+
+    /**
+     * Create PDF info device object.
+     *
+     * @param string $pdfInfoPath Path to toolbin/pdf_info.ps
+     *
+     * @return PdfInfo
+     */
+    public function createPdfInfoDevice($pdfInfoPath);
+
+    /**
+     * Create bounding box info device object.
+     *
+     * @return BoundingBoxInfo
+     */
+    public function createBoundingBoxInfoDevice();
+
+    /**
+     * Create inkcov device object
+     *
+     * @return Inkcov
+     */
+    public function createInkcovDevice();
+}

--- a/tests/src/Device/BoundingBoxInfoTest.php
+++ b/tests/src/Device/BoundingBoxInfoTest.php
@@ -7,6 +7,7 @@
 
 namespace GravityMedia\GhostscriptTest\Device;
 
+use GravityMedia\Ghostscript\Device\AbstractDevice;
 use GravityMedia\Ghostscript\Device\BoundingBoxInfo;
 use GravityMedia\Ghostscript\Ghostscript;
 use GravityMedia\Ghostscript\Process\Argument;
@@ -25,18 +26,20 @@ use PHPUnit\Framework\TestCase;
  * @uses    \GravityMedia\Ghostscript\Process\Argument
  * @uses    \GravityMedia\Ghostscript\Process\Arguments
  */
-class BoundingBoxInfoTest extends TestCase
+class BoundingBoxInfoTest extends DeviceTestCase
 {
+    protected function createDevice(?string $version = null): AbstractDevice
+    {
+        return new BoundingBoxInfo($this->getGhostscript($version), $this->arguments);
+    }
+
     public function testDeviceCreation()
     {
-        $ghostscript = new Ghostscript();
-        $arguments = new Arguments();
-
-        $device = new BoundingBoxInfo($ghostscript, $arguments);
+        $device = $this->createDevice();
 
         $this->assertInstanceOf(BoundingBoxInfo::class, $device);
 
-        $argument = $arguments->getArgument('-sDEVICE');
+        $argument = $this->arguments->getArgument('-sDEVICE');
 
         $this->assertInstanceOf(Argument::class, $argument);
         $this->assertEquals('bbox', $argument->getValue());

--- a/tests/src/Device/DeviceTestCase.php
+++ b/tests/src/Device/DeviceTestCase.php
@@ -31,7 +31,7 @@ abstract class DeviceTestCase extends TestCase
         } else {
             $ghostscript = $this->createPartialMock(Ghostscript::class, ['getVersion']);
 
-            $ghostscript->expects($this->once())
+            $ghostscript->expects($this->atLeastOnce())
                 ->method('getVersion')
                 ->will($this->returnValue($version));
         }

--- a/tests/src/Device/DeviceTestCase.php
+++ b/tests/src/Device/DeviceTestCase.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GravityMedia\GhostscriptTest\Device;
+
+use GravityMedia\Ghostscript\Device\AbstractDevice;
+use GravityMedia\Ghostscript\Ghostscript;
+use GravityMedia\Ghostscript\Process\Arguments;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Process\Process;
+
+abstract class DeviceTestCase extends TestCase
+{
+    protected Arguments $arguments;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->arguments = new Arguments();
+    }
+
+    abstract protected function createDevice(?string $version = null): AbstractDevice;
+
+    protected function getGhostscript(?string $version): Ghostscript|MockObject
+    {
+        if ($version === null) {
+            $ghostscript = new Ghostscript();
+        } else {
+            $ghostscript = $this->createPartialMock(Ghostscript::class, ['getVersion']);
+
+            $ghostscript->expects($this->once())
+                ->method('getVersion')
+                ->will($this->returnValue($version));
+        }
+        return $ghostscript;
+    }
+
+    public function dataVersionsChecks(): array
+    {
+        $minVersion = $this->getExpectedMinimumVersion();
+        return [
+            '8.50' => [fn (self $self) => $self->assertVersionCheck(
+                version: '8.50',
+                expectedFailure: true,
+            )],
+            $minVersion => [fn (self $self) => $self->assertVersionCheck(
+                version: $minVersion,
+                expectedFailure: false,
+            )],
+            '9.10' => [fn (self $self) => $self->assertVersionCheck(
+                version: '9.10',
+                expectedFailure: false,
+            )],
+            '9.50' => [fn (self $self) => $self->assertVersionCheck(
+                version: '9.50',
+                expectedFailure: false,
+            )],
+            '10.00.0' => [fn (self $self) => $self->assertVersionCheck(
+                version: '10.00.0', // Version from brew (Mac)
+                expectedFailure: false,
+            )]
+        ];
+    }
+
+    /**
+     * @dataProvider dataVersionsChecks
+     */
+    public function testVersionCheck(callable $closure): void
+    {
+        $closure($this);
+    }
+
+    protected function assertVersionCheck(
+        string $version,
+        bool $expectedFailure,
+    ): void
+    {
+        if ($expectedFailure) {
+            $expectedMinimumVersion = $this->getExpectedMinimumVersion();
+            $this->expectExceptionMessage('Ghostscript version ' . $expectedMinimumVersion . ' or higher is required');
+        }
+
+        $device = $this->createDevice($version);
+        $this->createProcessForVersionTest($device);
+    }
+
+    protected function getExpectedMinimumVersion(): string
+    {
+        return '9.00';
+    }
+
+    protected function createProcessForVersionTest(AbstractDevice $device): Process
+    {
+        return $device->createProcess();
+    }
+
+    /**
+     * Returns an OS independent representation of the commandline.
+     */
+    protected function quoteCommandLine(string $commandline): string
+    {
+        if ('WIN' === strtoupper(substr(PHP_OS, 0, 3))) {
+            return str_replace('"', '\'', $commandline);
+        }
+
+        return $commandline;
+    }
+}

--- a/tests/src/Device/InkcovTest.php
+++ b/tests/src/Device/InkcovTest.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace GravityMedia\Ghostscript\Device;
+namespace GravityMedia\GhostscriptTest\Device;
 
-use GravityMedia\Ghostscript\Ghostscript;
+use GravityMedia\Ghostscript\Device\AbstractDevice;
+use GravityMedia\Ghostscript\Device\Inkcov;
 use GravityMedia\Ghostscript\Process\Argument;
-use GravityMedia\Ghostscript\Process\Arguments;
-use PHPUnit\Framework\TestCase;
 
 /**
  * The inkcov device test class.
@@ -21,33 +20,19 @@ use PHPUnit\Framework\TestCase;
  * @uses    \GravityMedia\Ghostscript\Process\Argument
  * @uses    \GravityMedia\Ghostscript\Process\Arguments
  */
-class InkcovTest extends TestCase
+class InkcovTest extends DeviceTestCase
 {
-    /**
-     * Returns an OS independent representation of the commandline.
-     *
-     * @param string $commandline
-     *
-     * @return mixed
-     */
-    protected function quoteCommandLine($commandline)
+    protected function createDevice(?string $version = null): AbstractDevice
     {
-        if ('WIN' === strtoupper(substr(PHP_OS, 0, 3))) {
-            return str_replace('"', '\'', $commandline);
-        }
-
-        return $commandline;
+        return new Inkcov($this->getGhostscript($version), $this->arguments);
     }
 
     public function testDeviceCreation()
     {
-        $ghostscript = new Ghostscript();
-        $arguments = new Arguments();
-
-        $device = new Inkcov($ghostscript, $arguments);
+        $device = $this->createDevice();
 
         $this->assertInstanceOf(Inkcov::class, $device);
-        $this->assertInstanceOf(Argument::class, $arguments->getArgument('-sDEVICE'));
-        $this->assertEquals('inkcov', $arguments->getArgument('-sDEVICE')->getValue());
+        $this->assertInstanceOf(Argument::class, $this->arguments->getArgument('-sDEVICE'));
+        $this->assertEquals('inkcov', $this->arguments->getArgument('-sDEVICE')->getValue());
     }
 }

--- a/tests/src/Device/NoDisplayTest.php
+++ b/tests/src/Device/NoDisplayTest.php
@@ -7,11 +7,9 @@
 
 namespace GravityMedia\GhostscriptTest\Device;
 
+use GravityMedia\Ghostscript\Device\AbstractDevice;
 use GravityMedia\Ghostscript\Device\NoDisplay;
-use GravityMedia\Ghostscript\Ghostscript;
 use GravityMedia\Ghostscript\Process\Argument;
-use GravityMedia\Ghostscript\Process\Arguments;
-use PHPUnit\Framework\TestCase;
 
 /**
  * The no display device test class.
@@ -25,16 +23,20 @@ use PHPUnit\Framework\TestCase;
  * @uses    \GravityMedia\Ghostscript\Process\Argument
  * @uses    \GravityMedia\Ghostscript\Process\Arguments
  */
-class NoDisplayTest extends TestCase
+class NoDisplayTest extends DeviceTestCase
 {
+    protected function createDevice(?string $version = null): AbstractDevice
+    {
+        $ghostscript = $this->getGhostscript($version);
+
+        return new NoDisplay($ghostscript, $this->arguments);
+    }
+
     public function testDeviceCreation()
     {
-        $ghostscript = new Ghostscript();
-        $arguments = new Arguments();
-
-        $device = new NoDisplay($ghostscript, $arguments);
+        $device = $this->createDevice();
 
         $this->assertInstanceOf(NoDisplay::class, $device);
-        $this->assertInstanceOf(Argument::class, $arguments->getArgument('-dNODISPLAY'));
+        $this->assertInstanceOf(Argument::class, $this->arguments->getArgument('-dNODISPLAY'));
     }
 }

--- a/tests/src/GhostscriptTest.php
+++ b/tests/src/GhostscriptTest.php
@@ -52,27 +52,6 @@ class GhostscriptTest extends TestCase
     }
 
     /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Ghostscript version 9.00 or higher is required
-     */
-    public function testCreateGhostscriptObjectThrowsExceptionOnInvalidVersion()
-    {
-        $this->expectExceptionMessage('Ghostscript version 9.00 or higher is required');
-
-        $mock = $this->getMockBuilder(Ghostscript::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-
-        $mock->expects($this->once())
-            ->method('getVersion')
-            ->will($this->returnValue('8.00'));
-
-        $class = new \ReflectionClass(Ghostscript::class);
-        $constructor = $class->getConstructor();
-        $constructor->invoke($mock);
-    }
-
-    /**
      * @dataProvider provideOptions
      *
      * @param array  $options
@@ -101,17 +80,14 @@ class GhostscriptTest extends TestCase
     {
         $instance = new Ghostscript();
 
-        $this->assertMatchesRegularExpression('/^[0-9]\.[0-9]+$/', $instance->getVersion());
+        $this->assertMatchesRegularExpression('/^[0-9]+\.[0-9\.]+$/', $instance->getVersion());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testGetVersionThrowsExceptionOnFailure()
     {
-        $this->expectExceptionMessage('sh: /foo/bar/baz: No such file or directory');
-
-        new Ghostscript(['bin' => '/foo/bar/baz']);
+        $this->expectExceptionMessage('sh: line 0: exec: /foo/bar/baz: cannot execute: No such file or directory');
+        $ghostscript = new Ghostscript(['bin' => '/foo/bar/baz']);
+        $ghostscript->getVersion();
     }
 
     public function testProcessArgumentsCreation()


### PR DESCRIPTION
PR based on issue #16.

While doing PR I tried to prevent any breaking change but for the sake of cleaner code I've changed the structure of `protected function createProcessArguments(Input $input, string $version)`.

As the package is from PHP 8.0 it would be great do add typehints. If you are interested, I can do it (can be breaking change for those who extends the package). I can add also code fixer (I'm using ReactorPHP + [easy coding standard](https://github.com/symplify/coding-standard)).

Also as mentioned in issue, if you want to include support for Laravel I can prepare it. https://laravel.com/docs/10.x/packages#package-discovery

Let me know if you want to change something and thank you for your time.



